### PR TITLE
Remove legacy V1 airdrop record code

### DIFF
--- a/app/hooks/useAirdropRecord.ts
+++ b/app/hooks/useAirdropRecord.ts
@@ -1,20 +1,19 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import { fetchAirdropRecord, AirdropRecordResult } from '@/app/lib/solana/accounts';
+import { fetchAirdropRecord } from '@/app/lib/solana/accounts';
+import { AirdropRecordV2 } from '@/app/lib/solana/types';
 
 export interface AirdropData {
-  record: AirdropRecordResult | null;
+  record: AirdropRecordV2 | null;
   xnmAirdropped: bigint;
   xblkAirdropped: bigint;
   xuniAirdropped: bigint;
   nativeAirdropped: bigint;
   lastUpdated: bigint;
-  version: 1 | 2 | null;
 }
 
 export function useAirdropRecord(
-  solAddress: string | null,
   ethAddress: string | null
 ) {
   const [data, setData] = useState<AirdropData | null>(null);
@@ -30,7 +29,7 @@ export function useAirdropRecord(
     setIsLoading(true);
     setError(null);
 
-    fetchAirdropRecord(solAddress, ethAddress)
+    fetchAirdropRecord(ethAddress)
       .then((record) => {
         if (record) {
           setData({
@@ -40,7 +39,6 @@ export function useAirdropRecord(
             xuniAirdropped: record.xuniAirdropped,
             nativeAirdropped: record.nativeAirdropped,
             lastUpdated: record.lastUpdated,
-            version: record.version,
           });
         } else {
           setData({
@@ -50,7 +48,6 @@ export function useAirdropRecord(
             xuniAirdropped: 0n,
             nativeAirdropped: 0n,
             lastUpdated: 0n,
-            version: null,
           });
         }
       })
@@ -61,7 +58,7 @@ export function useAirdropRecord(
       .finally(() => {
         setIsLoading(false);
       });
-  }, [solAddress, ethAddress]);
+  }, [ethAddress]);
 
   return { data, isLoading, error };
 }

--- a/app/leaderboard/[slug]/page.tsx
+++ b/app/leaderboard/[slug]/page.tsx
@@ -42,7 +42,6 @@ export default function LeaderboardSlug({
 
   // Fetch airdrop record from on-chain
   const { data: airdropData, isLoading: isLoadingAirdrop } = useAirdropRecord(
-    x1Address || null,
     leaderboardEntry.account || null
   );
 

--- a/app/lib/solana/accounts.ts
+++ b/app/lib/solana/accounts.ts
@@ -1,21 +1,8 @@
 import { Connection, PublicKey } from '@solana/web3.js';
-import { deriveAirdropRecordPDA, deriveAirdropRecordPDALegacy } from './pda';
-import { deserializeAirdropRecord, deserializeAirdropRecordV2 } from './deserialize';
+import { deriveAirdropRecordPDA } from './pda';
+import { deserializeAirdropRecordV2 } from './deserialize';
+import { AirdropRecordV2 } from './types';
 import { config } from './config';
-
-/**
- * Unified result type for both V1 and V2 airdrop records
- */
-export interface AirdropRecordResult {
-  ethAddress: number[];
-  xnmAirdropped: bigint;
-  xblkAirdropped: bigint;
-  xuniAirdropped: bigint;
-  nativeAirdropped: bigint;
-  lastUpdated: bigint;
-  bump: number;
-  version: 1 | 2;
-}
 
 let connection: Connection | null = null;
 
@@ -27,55 +14,20 @@ function getConnection(): Connection {
 }
 
 /**
- * Fetch a single airdrop record by ETH address (V2 first, V1 fallback)
+ * Fetch a single airdrop record by ETH address
  */
 export async function fetchAirdropRecord(
-  solAddress: string | null,
   ethAddress: string
-): Promise<AirdropRecordResult | null> {
+): Promise<AirdropRecordV2 | null> {
   const conn = getConnection();
   const programId = new PublicKey(config.programId);
 
-  // Try V2 PDA first (ETH-only)
-  const [v2Pda] = deriveAirdropRecordPDA(programId, ethAddress);
-  const v2Account = await conn.getAccountInfo(v2Pda);
+  const [pda] = deriveAirdropRecordPDA(programId, ethAddress);
+  const accountInfo = await conn.getAccountInfo(pda);
 
-  if (v2Account) {
-    const record = deserializeAirdropRecordV2(v2Account.data);
-    return {
-      ethAddress: record.ethAddress,
-      xnmAirdropped: record.xnmAirdropped,
-      xblkAirdropped: record.xblkAirdropped,
-      xuniAirdropped: record.xuniAirdropped,
-      nativeAirdropped: record.nativeAirdropped,
-      lastUpdated: record.lastUpdated,
-      bump: record.bump,
-      version: 2,
-    };
-  }
-
-  // Fall back to V1 PDA (requires sol_wallet)
-  if (!solAddress) {
+  if (!accountInfo) {
     return null;
   }
 
-  const solWallet = new PublicKey(solAddress);
-  const [v1Pda] = deriveAirdropRecordPDALegacy(programId, solWallet, ethAddress);
-  const v1Account = await conn.getAccountInfo(v1Pda);
-
-  if (!v1Account) {
-    return null;
-  }
-
-  const record = deserializeAirdropRecord(v1Account.data);
-  return {
-    ethAddress: record.ethAddress,
-    xnmAirdropped: record.xnmAirdropped,
-    xblkAirdropped: record.xblkAirdropped,
-    xuniAirdropped: record.xuniAirdropped,
-    nativeAirdropped: record.nativeAirdropped,
-    lastUpdated: record.lastUpdated,
-    bump: record.bump,
-    version: 1,
-  };
+  return deserializeAirdropRecordV2(accountInfo.data);
 }

--- a/app/lib/solana/deserialize.ts
+++ b/app/lib/solana/deserialize.ts
@@ -1,95 +1,10 @@
-import { PublicKey } from '@solana/web3.js';
 import {
-  AIRDROP_RECORD_OFFSETS,
   AIRDROP_RECORD_V2_OFFSETS,
-  AIRDROP_RECORD_LEGACY_OFFSETS,
-  AIRDROP_RECORD_LEGACY_SIZE,
-  AirdropRecord,
   AirdropRecordV2,
 } from './types';
 
 /**
- * Deserialize an AirdropRecord (V1) from account data
- * Handles both legacy (99 bytes) and current (155 bytes) V1 schemas
- */
-export function deserializeAirdropRecord(data: Uint8Array): AirdropRecord {
-  const buffer = Buffer.from(data);
-  const isLegacySchema = data.length === AIRDROP_RECORD_LEGACY_SIZE;
-
-  const solWallet = new PublicKey(
-    buffer.slice(
-      AIRDROP_RECORD_OFFSETS.SOL_WALLET,
-      AIRDROP_RECORD_OFFSETS.ETH_ADDRESS
-    )
-  );
-
-  const ethAddress = Array.from(
-    buffer.slice(
-      AIRDROP_RECORD_OFFSETS.ETH_ADDRESS,
-      AIRDROP_RECORD_OFFSETS.XNM_AIRDROPPED
-    )
-  );
-
-  if (isLegacySchema) {
-    const totalAirdropped = buffer.readBigUInt64LE(
-      AIRDROP_RECORD_LEGACY_OFFSETS.TOTAL_AIRDROPPED
-    );
-    const lastUpdated = buffer.readBigInt64LE(
-      AIRDROP_RECORD_LEGACY_OFFSETS.LAST_UPDATED
-    );
-    const bump = buffer.readUInt8(AIRDROP_RECORD_LEGACY_OFFSETS.BUMP);
-
-    return {
-      solWallet,
-      ethAddress,
-      xnmAirdropped: totalAirdropped,
-      xblkAirdropped: 0n,
-      xuniAirdropped: 0n,
-      nativeAirdropped: 0n,
-      reserved: [0n, 0n, 0n, 0n],
-      lastUpdated,
-      bump,
-    };
-  }
-
-  const xnmAirdropped = buffer.readBigUInt64LE(
-    AIRDROP_RECORD_OFFSETS.XNM_AIRDROPPED
-  );
-  const xblkAirdropped = buffer.readBigUInt64LE(
-    AIRDROP_RECORD_OFFSETS.XBLK_AIRDROPPED
-  );
-  const xuniAirdropped = buffer.readBigUInt64LE(
-    AIRDROP_RECORD_OFFSETS.XUNI_AIRDROPPED
-  );
-  const nativeAirdropped = buffer.readBigUInt64LE(
-    AIRDROP_RECORD_OFFSETS.NATIVE_AIRDROPPED
-  );
-
-  const reserved: bigint[] = [];
-  for (let i = 0; i < 4; i++) {
-    reserved.push(
-      buffer.readBigUInt64LE(AIRDROP_RECORD_OFFSETS.RESERVED + i * 8)
-    );
-  }
-
-  const lastUpdated = buffer.readBigInt64LE(AIRDROP_RECORD_OFFSETS.LAST_UPDATED);
-  const bump = buffer.readUInt8(AIRDROP_RECORD_OFFSETS.BUMP);
-
-  return {
-    solWallet,
-    ethAddress,
-    xnmAirdropped,
-    xblkAirdropped,
-    xuniAirdropped,
-    nativeAirdropped,
-    reserved,
-    lastUpdated,
-    bump,
-  };
-}
-
-/**
- * Deserialize an AirdropRecordV2 from account data (123 bytes, no sol_wallet)
+ * Deserialize an AirdropRecordV2 from account data (123 bytes)
  */
 export function deserializeAirdropRecordV2(data: Uint8Array): AirdropRecordV2 {
   const buffer = Buffer.from(data);

--- a/app/lib/solana/pda.ts
+++ b/app/lib/solana/pda.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from '@solana/web3.js';
 
 /**
- * Derive the PDA for an airdrop record (V2 — ETH-only, no sol_wallet)
+ * Derive the PDA for an airdrop record
  * Normalizes ETH address to lowercase to prevent case-sensitive PDA collisions.
  *
  * Seeds: ["airdrop_record_v2", eth_address[0..21], eth_address[21..42]]
@@ -23,23 +23,6 @@ export function deriveAirdropRecordPDA(
       ethBytes.subarray(0, 21),
       ethBytes.subarray(21, 42),
     ],
-    programId
-  );
-}
-
-/**
- * Derive the PDA for an airdrop record (V1 legacy — includes sol_wallet)
- *
- * Seeds: ["airdrop_record", sol_wallet, eth_address[0..20]]
- */
-export function deriveAirdropRecordPDALegacy(
-  programId: PublicKey,
-  solWallet: PublicKey,
-  ethAddress: string
-): [PublicKey, number] {
-  const ethBytes = Buffer.from(ethAddress).slice(0, 20);
-  return PublicKey.findProgramAddressSync(
-    [Buffer.from('airdrop_record'), solWallet.toBuffer(), ethBytes],
     programId
   );
 }

--- a/app/lib/solana/types.ts
+++ b/app/lib/solana/types.ts
@@ -1,22 +1,5 @@
-import { PublicKey } from '@solana/web3.js';
-
 /**
- * On-chain AirdropRecord V1 account data structure (155 bytes, includes sol_wallet)
- */
-export interface AirdropRecord {
-  solWallet: PublicKey;
-  ethAddress: number[]; // [u8; 42]
-  xnmAirdropped: bigint;
-  xblkAirdropped: bigint;
-  xuniAirdropped: bigint;
-  nativeAirdropped: bigint;
-  reserved: bigint[]; // [u64; 4]
-  lastUpdated: bigint;
-  bump: number;
-}
-
-/**
- * On-chain AirdropRecordV2 account data structure (123 bytes, ETH-only key)
+ * On-chain AirdropRecord account data structure (123 bytes, ETH-only PDA)
  */
 export interface AirdropRecordV2 {
   ethAddress: number[]; // [u8; 42]
@@ -30,25 +13,7 @@ export interface AirdropRecordV2 {
 }
 
 /**
- * Offset constants for AirdropRecord V1 deserialization (155 bytes)
- */
-export const AIRDROP_RECORD_OFFSETS = {
-  DISCRIMINATOR: 0,
-  SOL_WALLET: 8,
-  ETH_ADDRESS: 8 + 32,
-  XNM_AIRDROPPED: 8 + 32 + 42,
-  XBLK_AIRDROPPED: 8 + 32 + 42 + 8,
-  XUNI_AIRDROPPED: 8 + 32 + 42 + 8 + 8,
-  NATIVE_AIRDROPPED: 8 + 32 + 42 + 8 + 8 + 8,
-  RESERVED: 8 + 32 + 42 + 8 + 8 + 8 + 8,
-  LAST_UPDATED: 8 + 32 + 42 + 8 + 8 + 8 + 8 + 32,
-  BUMP: 8 + 32 + 42 + 8 + 8 + 8 + 8 + 32 + 8,
-} as const;
-
-export const AIRDROP_RECORD_SIZE = 8 + 32 + 42 + 8 + 8 + 8 + 8 + 32 + 8 + 1; // 155 bytes
-
-/**
- * Offset constants for AirdropRecordV2 deserialization (123 bytes, no sol_wallet)
+ * Offset constants for AirdropRecord deserialization (123 bytes)
  */
 export const AIRDROP_RECORD_V2_OFFSETS = {
   DISCRIMINATOR: 0,
@@ -63,17 +28,3 @@ export const AIRDROP_RECORD_V2_OFFSETS = {
 } as const;
 
 export const AIRDROP_RECORD_V2_SIZE = 8 + 42 + 8 + 8 + 8 + 8 + 32 + 8 + 1; // 123 bytes
-
-/**
- * Offset constants for AirdropRecord deserialization (OLD/legacy schema, 99 bytes)
- */
-export const AIRDROP_RECORD_LEGACY_OFFSETS = {
-  DISCRIMINATOR: 0,
-  SOL_WALLET: 8,
-  ETH_ADDRESS: 8 + 32,
-  TOTAL_AIRDROPPED: 8 + 32 + 42,
-  LAST_UPDATED: 8 + 32 + 42 + 8,
-  BUMP: 8 + 32 + 42 + 8 + 8,
-} as const;
-
-export const AIRDROP_RECORD_LEGACY_SIZE = 8 + 32 + 42 + 8 + 8 + 1; // 99 bytes


### PR DESCRIPTION
## Summary

- Remove `AirdropRecord` V1 interface and V1/legacy offset constants
- Remove `deriveAirdropRecordPDALegacy` PDA function
- Remove `deserializeAirdropRecord` V1 deserializer (99-byte and 155-byte schemas)
- Simplify `fetchAirdropRecord` to V2-only (no more V1 fallback)
- Remove `version` field from `AirdropData` and `AirdropRecordResult`
- Simplify `useAirdropRecord` hook — only needs `ethAddress`, no longer needs `solAddress`

All records have been migrated to V2 ETH-only PDAs. This is a pure deletion of dead code (-221 lines).

## Test plan

- [x] `npm run build` passes
- [ ] Dev server: verify miner detail pages still display airdrop amounts correctly